### PR TITLE
Fix a TypeError by removing the keyword argument

### DIFF
--- a/tautulli/internal/utils.py
+++ b/tautulli/internal/utils.py
@@ -18,7 +18,7 @@ def datetime_to_string(datetime_object: datetime, string_format: str = "%Y-%m-%d
     """
     if not datetime_object:
         return None
-    return datetime_object.strftime(fmt=string_format)
+    return datetime_object.strftime(string_format)
 
 
 def build_optional_params(**kwargs) -> dict:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+
+from tautulli.internal.utils import (
+    datetime_to_string
+)
+
+def test_datetime_to_string():
+    date = datetime(2021, 1, 1, 0, 0, 0)
+
+    # default format: "%Y-%m-%d"
+    assert datetime_to_string(datetime_object=date) == "2021-01-01"
+
+    fmt = "%Y-%m-%d %H:%M:%S"
+    assert datetime_to_string(datetime_object=date, string_format=fmt) == "2021-01-01 00:00:00"


### PR DESCRIPTION
Attempt at fixing #33  by removing the keyword argument from `strftime()`