### PR TITLE
[fix] Include requirements.txt and requirements-dev.txt in build for PiWheel

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 include LICENSE
 include tautulli/API_VERSIONS.json
 include tautulli/PYTHON_VERSIONS.json
+include requirements.txt
+include requirements-dev.txt


### PR DESCRIPTION
Looking at the logs for PiWheel, which stopped uploading the `tautulli` package after v3.4.0, it seems that it can't find a "requirements.txt" file to read from for setup: https://www.piwheels.org/project/tautulli/

This does coincide with changes that were made between 3.4.0 and 3.4.1 regarding the setup process; namely, moving dependency listing to requirements.txt files. These files, however, weren't included in the final egg and therefore could not be found and read for the purposes of a wheel.

Thankfully, we've previously included files like API_VERSIONS, so this should be a simple fix now that we know how to do it.