### PR TITLE
[fix] `markers` property of Metadata class is a list

### DIFF
--- a/.idea/pytulli.iml
+++ b/.idea/pytulli.iml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.venv" />
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
+      <excludeFolder url="file://$MODULE_DIR$/docs" />
+    </content>
+    <orderEntry type="jdk" jdkName="Python 3.12 (pytulli)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="py.test" />
+  </component>
+</module>

--- a/tautulli/models/metadata.py
+++ b/tautulli/models/metadata.py
@@ -147,7 +147,7 @@ class MetadataModel(BaseModel):
     live: Optional[int] = None
     media_info: Optional[List[MediaInfoItemModel]] = None
     edition_title: Optional[str] = None
-    markers: Optional[MarkerModel] = None
+    markers: Optional[List[MarkerModel]] = None
     slug: Optional[str] = None
     parent_slug: Optional[str] = None
     grandparent_slug: Optional[str] = None


### PR DESCRIPTION
Closes #57 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new XML configuration for the Python module in the project.
	- Configured the project to use `py.test` as the test runner.

- **Bug Fixes**
	- Updated the `markers` attribute to support multiple instances in the metadata model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->