### PR TITLE
Handle API returning empty strings for numeric fields

### DIFF
--- a/tautulli/models/_base.py
+++ b/tautulli/models/_base.py
@@ -1,0 +1,23 @@
+from typing import Union, Optional, Any
+
+from pydantic import BaseModel, BeforeValidator, Field
+from typing_extensions import Annotated
+
+
+# ref: https://docs.pydantic.dev/latest/concepts/validators/#using-the-annotated-pattern
+def empty_string_to_none(value: Any) -> Union[str, None]:
+    """
+    Handle coercing empty strings to None.
+    :param value: The value to be converted.
+    :return: None if the value is an empty string, otherwise the original value.
+    """
+    return value if value != "" else None
+
+
+EmptyStringNullableInt = Annotated[Optional[int], BeforeValidator(empty_string_to_none)]
+
+EmptyStringNullableFloat = Annotated[Optional[float], BeforeValidator(empty_string_to_none)]
+
+
+class _Base(BaseModel):
+    pass

--- a/tautulli/models/_base.py
+++ b/tautulli/models/_base.py
@@ -14,9 +14,9 @@ def empty_string_to_none(value: Any) -> Union[str, None]:
     return value if value != "" else None
 
 
-EmptyStringNullableInt = Annotated[Optional[int], BeforeValidator(empty_string_to_none)]
+EmptyStringNullableInt: Union[int, None] = Annotated[Optional[int], BeforeValidator(empty_string_to_none)]
 
-EmptyStringNullableFloat = Annotated[Optional[float], BeforeValidator(empty_string_to_none)]
+EmptyStringNullableFloat: Union[float, None] = Annotated[Optional[float], BeforeValidator(empty_string_to_none)]
 
 
 class _Base(BaseModel):

--- a/tautulli/models/activity.py
+++ b/tautulli/models/activity.py
@@ -4,15 +4,14 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
-
-from pydantic import BaseModel
+from typing import List, Optional
 
 from tautulli.internal import utils as internal_utils, static
+from tautulli.models._base import _Base, EmptyStringNullableInt
 from tautulli.tools.utils import to_human_bitrate
 
 
-class SessionModel(BaseModel):
+class SessionModel(_Base):
     session_key: Optional[str] = None
     media_type: Optional[str] = None
     view_offset: Optional[str] = None
@@ -21,7 +20,7 @@ class SessionModel(BaseModel):
     synced_version_profile: Optional[str] = None
     optimized_version_profile: Optional[str] = None
     user: Optional[str] = None
-    channel_stream: Optional[int] = None
+    channel_stream: EmptyStringNullableInt = None
     section_id: Optional[str] = None
     library_name: Optional[str] = None
     rating_key: Optional[str] = None
@@ -65,8 +64,8 @@ class SessionModel(BaseModel):
     collections: Optional[List] = None
     guids: Optional[List] = None
     full_title: Optional[str] = None
-    children_count: Optional[int] = None
-    live: Optional[int] = None
+    children_count: EmptyStringNullableInt = None
+    live: EmptyStringNullableInt = None
     id: Optional[str] = None
     container: Optional[str] = None
     bitrate: Optional[str] = None
@@ -82,7 +81,7 @@ class SessionModel(BaseModel):
     audio_channels: Optional[str] = None
     audio_channel_layout: Optional[str] = None
     audio_profile: Optional[str] = None
-    optimized_version: Optional[int] = None
+    optimized_version: EmptyStringNullableInt = None
     channel_call_sign: Optional[str] = None
     channel_id: Optional[str] = None
     channel_identifier: Optional[str] = None
@@ -91,8 +90,8 @@ class SessionModel(BaseModel):
     channel_vcn: Optional[str] = None
     file: Optional[str] = None
     file_size: Optional[str] = None
-    indexes: Optional[int] = None
-    selected: Optional[int] = None
+    indexes: EmptyStringNullableInt = None
+    selected: EmptyStringNullableInt = None
     type: Optional[str] = None
     video_codec_level: Optional[str] = None
     video_bitrate: Optional[str] = None
@@ -117,25 +116,25 @@ class SessionModel(BaseModel):
     subtitle_codec: Optional[str] = None
     subtitle_container: Optional[str] = None
     subtitle_format: Optional[str] = None
-    subtitle_forced: Optional[int] = None
+    subtitle_forced: EmptyStringNullableInt = None
     subtitle_location: Optional[str] = None
     subtitle_language: Optional[str] = None
     subtitle_language_code: Optional[str] = None
-    row_id: Optional[int] = None
-    user_id: Optional[int] = None
+    row_id: EmptyStringNullableInt = None
+    user_id: EmptyStringNullableInt = None
     username: Optional[str] = None
     friendly_name: Optional[str] = None
     user_thumb: Optional[str] = None
     email: Optional[str] = None
-    is_active: Optional[int] = None
-    is_admin: Optional[int] = None
-    is_home_user: Optional[int] = None
-    is_allow_sync: Optional[int] = None
-    is_restricted: Optional[int] = None
-    do_notify: Optional[int] = None
-    keep_history: Optional[int] = None
-    deleted_user: Optional[int] = None
-    allow_guest: Optional[int] = None
+    is_active: EmptyStringNullableInt = None
+    is_admin: EmptyStringNullableInt = None
+    is_home_user: EmptyStringNullableInt = None
+    is_allow_sync: EmptyStringNullableInt = None
+    is_restricted: EmptyStringNullableInt = None
+    do_notify: EmptyStringNullableInt = None
+    keep_history: EmptyStringNullableInt = None
+    deleted_user: EmptyStringNullableInt = None
+    allow_guest: EmptyStringNullableInt = None
     shared_libraries: Optional[List[str]] = None
     ip_address: Optional[str] = None
     ip_address_public: Optional[str] = None
@@ -149,15 +148,15 @@ class SessionModel(BaseModel):
     player: Optional[str] = None
     machine_id: Optional[str] = None
     state: Optional[str] = None
-    local: Optional[int] = None
-    relayed: Optional[int] = None
-    secure: Optional[int] = None
+    local: EmptyStringNullableInt = None
+    relayed: EmptyStringNullableInt = None
+    secure: EmptyStringNullableInt = None
     session_id: Optional[str] = None
     bandwidth: Optional[str] = None
     location: Optional[str] = None
     transcode_key: Optional[str] = None
-    transcode_throttled: Optional[int] = None
-    transcode_progress: Optional[int] = None
+    transcode_throttled: EmptyStringNullableInt = None
+    transcode_progress: EmptyStringNullableInt = None
     transcode_speed: Optional[str] = None
     transcode_audio_channels: Optional[str] = None
     transcode_audio_codec: Optional[str] = None
@@ -166,20 +165,20 @@ class SessionModel(BaseModel):
     transcode_height: Optional[str] = None
     transcode_container: Optional[str] = None
     transcode_protocol: Optional[str] = None
-    transcode_hw_requested: Optional[int] = None
+    transcode_hw_requested: EmptyStringNullableInt = None
     transcode_hw_decode: Optional[str] = None
     transcode_hw_decode_title: Optional[str] = None
     transcode_hw_encode: Optional[str] = None
     transcode_hw_encode_title: Optional[str] = None
-    transcode_hw_full_pipeline: Optional[int] = None
-    transcode_max_offset_available: Optional[int] = None
-    transcode_min_offset_available: Optional[int] = None
+    transcode_hw_full_pipeline: EmptyStringNullableInt = None
+    transcode_max_offset_available: EmptyStringNullableInt = None
+    transcode_min_offset_available: EmptyStringNullableInt = None
     audio_decision: Optional[str] = None
     video_decision: Optional[str] = None
     subtitle_decision: Optional[str] = None
     throttled: Optional[str] = None
-    transcode_hw_decoding: Optional[int] = None
-    transcode_hw_encoding: Optional[int] = None
+    transcode_hw_decoding: EmptyStringNullableInt = None
+    transcode_hw_encoding: EmptyStringNullableInt = None
     stream_container: Optional[str] = None
     stream_bitrate: Optional[str] = None
     stream_aspect_ratio: Optional[str] = None
@@ -194,10 +193,10 @@ class SessionModel(BaseModel):
     stream_duration: Optional[str] = None
     stream_container_decision: Optional[str] = None
     optimized_version_title: Optional[str] = None
-    synced_version: Optional[int] = None
+    synced_version: EmptyStringNullableInt = None
     live_uuid: Optional[str] = None
     bif_thumb: Optional[str] = None
-    subtitles: Optional[int] = None
+    subtitles: EmptyStringNullableInt = None
     transcode_decision: Optional[str] = None
     container_decision: Optional[str] = None
     stream_video_full_resolution: Optional[str] = None
@@ -226,12 +225,12 @@ class SessionModel(BaseModel):
     stream_subtitle_codec: Optional[str] = None
     stream_subtitle_container: Optional[str] = None
     stream_subtitle_format: Optional[str] = None
-    stream_subtitle_forced: Optional[int] = None
+    stream_subtitle_forced: EmptyStringNullableInt = None
     stream_subtitle_location: Optional[str] = None
     stream_subtitle_language: Optional[str] = None
     stream_subtitle_language_code: Optional[str] = None
     stream_subtitle_decision: Optional[str] = None
-    stream_subtitle_transient: Optional[int] = None
+    stream_subtitle_transient: EmptyStringNullableInt = None
 
     @property
     def duration_milliseconds(self):
@@ -308,26 +307,26 @@ class SessionModel(BaseModel):
                f"{static.session_progress_message.format(progress=self.progress_marker, eta=self.eta)}"
 
 
-class ActivityModel(BaseModel):
+class ActivityModel(_Base):
     stream_count: Optional[str] = None
     sessions: Optional[List[SessionModel]] = None
-    stream_count_direct_play: Optional[int] = None
-    stream_count_direct_stream: Optional[int] = None
-    stream_count_transcode: Optional[int] = None
-    total_bandwidth: Optional[int] = None
-    lan_bandwidth: Optional[int] = None
-    wan_bandwidth: Optional[int] = None
+    stream_count_direct_play: EmptyStringNullableInt = None
+    stream_count_direct_stream: EmptyStringNullableInt = None
+    stream_count_transcode: EmptyStringNullableInt = None
+    total_bandwidth: EmptyStringNullableInt = None
+    lan_bandwidth: EmptyStringNullableInt = None
+    wan_bandwidth: EmptyStringNullableInt = None
 
     @property
     def summary(self) -> ActivitySummaryModel:
         return build_summary_from_activity_object(activity=self)
 
 
-class ActivitySummaryModel(BaseModel):
+class ActivitySummaryModel(_Base):
     stream_count: Optional[str] = "0"
-    transcode_count: Optional[int] = 0
-    total_bandwidth: Optional[int] = 0
-    lan_bandwidth: Optional[int] = 0
+    transcode_count: EmptyStringNullableInt = 0
+    total_bandwidth: EmptyStringNullableInt = 0
+    lan_bandwidth: EmptyStringNullableInt = 0
 
     @property
     def message(self):

--- a/tautulli/models/children_metadata.py
+++ b/tautulli/models/children_metadata.py
@@ -4,12 +4,12 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import List, Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class ChildrenListItemModel(BaseModel):
+class ChildrenListItemModel(_Base):
     actors: Optional[List] = None
     added_at: Optional[str] = None
     art: Optional[str] = None
@@ -54,8 +54,8 @@ class ChildrenListItemModel(BaseModel):
     collections: Optional[List] = None
 
 
-class ChildrenMetadataModel(BaseModel):
-    children_count: Optional[int] = None
+class ChildrenMetadataModel(_Base):
+    children_count: EmptyStringNullableInt = None
     children_type: Optional[str] = None
     title: Optional[str] = None
     children_list: Optional[List[ChildrenListItemModel]] = None

--- a/tautulli/models/collections_table.py
+++ b/tautulli/models/collections_table.py
@@ -6,22 +6,22 @@ from __future__ import annotations
 
 from typing import Any, List, Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class DatumModel(BaseModel):
+class DatumModel(_Base):
     addedAt: Optional[str] = None
     art: Optional[Any] = None
-    childCount: Optional[int] = None
-    collectionMode: Optional[int] = None
-    collectionSort: Optional[int] = None
+    childCount: EmptyStringNullableInt = None
+    collectionMode: EmptyStringNullableInt = None
+    collectionSort: EmptyStringNullableInt = None
     contentRating: Optional[str] = None
     guid: Optional[str] = None
     librarySectionID: Optional[str] = None
     librarySectionTitle: Optional[str] = None
-    maxYear: Optional[int] = None
-    minYear: Optional[int] = None
-    ratingKey: Optional[int] = None
+    maxYear: EmptyStringNullableInt = None
+    minYear: EmptyStringNullableInt = None
+    ratingKey: EmptyStringNullableInt = None
     subtype: Optional[str] = None
     summary: Optional[str] = None
     thumb: Optional[str] = None
@@ -31,11 +31,11 @@ class DatumModel(BaseModel):
     updatedAt: Optional[str] = None
 
 
-class CollectionsTableModel(BaseModel):
-    recordsFiltered: Optional[int] = None
-    recordsTotal: Optional[int] = None
+class CollectionsTableModel(_Base):
+    recordsFiltered: EmptyStringNullableInt = None
+    recordsTotal: EmptyStringNullableInt = None
     data: Optional[List[DatumModel]] = None
-    draw: Optional[int] = None
+    draw: EmptyStringNullableInt = None
 
 
 

--- a/tautulli/models/date_formats.py
+++ b/tautulli/models/date_formats.py
@@ -4,11 +4,11 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base
 
 
-class DateFormatsModel(BaseModel):
+class DateFormatsModel(_Base):
     date_format: Optional[str] = None
     time_format: Optional[str] = None

--- a/tautulli/models/docs.py
+++ b/tautulli/models/docs.py
@@ -4,12 +4,12 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base
 
 
-class DocsModel(BaseModel):
+class DocsModel(_Base):
     add_newsletter_config: Optional[str] = None
     add_notifier_config: Optional[str] = None
     arnold: Optional[str] = None

--- a/tautulli/models/export_fields.py
+++ b/tautulli/models/export_fields.py
@@ -6,19 +6,19 @@ from __future__ import annotations
 
 from typing import List, Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class MetadataFieldModel(BaseModel):
+class MetadataFieldModel(_Base):
     field: Optional[str] = None
-    level: Optional[int] = None
+    level: EmptyStringNullableInt = None
 
 
-class MediaInfoFieldModel(BaseModel):
+class MediaInfoFieldModel(_Base):
     field: Optional[str] = None
-    level: Optional[int] = None
+    level: EmptyStringNullableInt = None
 
 
-class ExportFieldsModel(BaseModel):
+class ExportFieldsModel(_Base):
     metadata_fields: Optional[List[MetadataFieldModel]] = None
     media_info_fields: Optional[List[MediaInfoFieldModel]] = None

--- a/tautulli/models/exports_table.py
+++ b/tautulli/models/exports_table.py
@@ -6,38 +6,38 @@ from __future__ import annotations
 
 from typing import Any, List, Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class DatumModel(BaseModel):
-    timestamp: Optional[int] = None
-    art_level: Optional[int] = None
-    complete: Optional[int] = None
+class DatumModel(_Base):
+    timestamp: EmptyStringNullableInt = None
+    art_level: EmptyStringNullableInt = None
+    complete: EmptyStringNullableInt = None
     custom_fields: str
     exists: Optional[bool] = None
-    export_id: Optional[int] = None
-    exported_items: Optional[int] = None
+    export_id: EmptyStringNullableInt = None
+    exported_items: EmptyStringNullableInt = None
     file_format: Optional[str] = None
-    file_size: Optional[int] = None
+    file_size: EmptyStringNullableInt = None
     filename: Optional[Any] = None
-    individual_files: Optional[int] = None
-    logo_level: Optional[int] = None
-    media_info_level: Optional[int] = None
+    individual_files: EmptyStringNullableInt = None
+    logo_level: EmptyStringNullableInt = None
+    media_info_level: EmptyStringNullableInt = None
     media_type: Optional[str] = None
     media_type_title: Optional[str] = None
-    metadata_level: Optional[int] = None
+    metadata_level: EmptyStringNullableInt = None
     rating_key: Optional[Any] = None
-    section_id: Optional[int] = None
-    thumb_level: Optional[int] = None
+    section_id: EmptyStringNullableInt = None
+    thumb_level: EmptyStringNullableInt = None
     title: Optional[str] = None
-    total_items: Optional[int] = None
+    total_items: EmptyStringNullableInt = None
     user_id: Optional[Any] = None
 
 
-class ExportsTableModel(BaseModel):
-    draw: Optional[int] = None
-    recordsTotal: Optional[int] = None
-    recordsFiltered: Optional[int] = None
+class ExportsTableModel(_Base):
+    draw: EmptyStringNullableInt = None
+    recordsTotal: EmptyStringNullableInt = None
+    recordsFiltered: EmptyStringNullableInt = None
     data: Optional[List[DatumModel]] = None
 
 

--- a/tautulli/models/geo_ip_lookup.py
+++ b/tautulli/models/geo_ip_lookup.py
@@ -4,18 +4,18 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableFloat
 
 
-class GeoIPLookupModel(BaseModel):
+class GeoIPLookupModel(_Base):
     city: Optional[str] = None
     code: Optional[str] = None
     continent: Optional[str] = None
     country: Optional[str] = None
-    latitude: Optional[Union[float, None]] = None
-    longitude: Optional[Union[float, None]] = None
+    latitude: EmptyStringNullableFloat = None
+    longitude: EmptyStringNullableFloat = None
     postal_code: Optional[str] = None
     region: Optional[str] = None
     timezone: Optional[str] = None

--- a/tautulli/models/get_plays_or_stream_types_by.py
+++ b/tautulli/models/get_plays_or_stream_types_by.py
@@ -4,17 +4,17 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import List, Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base
 
 
-class SeriesModel(BaseModel):
+class SeriesModel(_Base):
     name: Optional[str] = None
     data: Optional[List] = None
 
 
-class PlaysOrStreamTypesByModel(BaseModel):
+class PlaysOrStreamTypesByModel(_Base):
     categories: Optional[List[str]] = None
     series: Optional[List[SeriesModel]] = None
 

--- a/tautulli/models/history.py
+++ b/tautulli/models/history.py
@@ -4,22 +4,22 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Union, Optional
+from typing import Any, List, Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt, EmptyStringNullableFloat
 
 
-class DatumModel(BaseModel):
-    reference_id: Optional[int] = None
-    row_id: Optional[int] = None
-    id: Optional[int] = None
-    date: Optional[int] = None
-    started: Optional[int] = None
-    stopped: Optional[int] = None
-    duration: Optional[int] = None # Keep for backwards compatibility
-    play_duration: Optional[int] = None
-    paused_counter: Optional[int] = None
-    user_id: Optional[int] = None
+class DatumModel(_Base):
+    reference_id: EmptyStringNullableInt = None
+    row_id: EmptyStringNullableInt = None
+    id: EmptyStringNullableInt = None
+    date: EmptyStringNullableInt = None
+    started: EmptyStringNullableInt = None
+    stopped: EmptyStringNullableInt = None
+    duration: EmptyStringNullableInt = None # Keep for backwards compatibility
+    play_duration: EmptyStringNullableInt = None
+    paused_counter: EmptyStringNullableInt = None
+    user_id: EmptyStringNullableInt = None
     user: Optional[str] = None
     friendly_name: Optional[str] = None
     user_thumb: Optional[str] = None
@@ -27,37 +27,37 @@ class DatumModel(BaseModel):
     product: Optional[str] = None
     player: Optional[str] = None
     ip_address: Optional[str] = None
-    live: Optional[int] = None
+    live: EmptyStringNullableInt = None
     machine_id: Optional[str] = None
     media_type: Optional[str] = None
-    rating_key: Optional[int] = None
-    parent_rating_key: Optional[Union[int, str]] = None
-    grandparent_rating_key: Optional[Union[int, str]] = None
+    rating_key: EmptyStringNullableInt = None
+    parent_rating_key: EmptyStringNullableInt = None
+    grandparent_rating_key: EmptyStringNullableInt = None
     full_title: Optional[str] = None
     title: Optional[str] = None
     parent_title: Optional[str] = None
     grandparent_title: Optional[str] = None
     original_title: Optional[str] = None
-    year: Optional[Union[int, str]] = None
-    media_index: Optional[Union[int, str]] = None
-    parent_media_index: Optional[Union[int, str]] = None
+    year: EmptyStringNullableInt = None
+    media_index: EmptyStringNullableInt = None
+    parent_media_index: EmptyStringNullableInt = None
     thumb: Optional[str] = None
     originally_available_at: Optional[str] = None
     guid: Optional[str] = None
     transcode_decision: Optional[str] = None
-    percent_complete: Optional[int] = None
-    watched_status: Optional[float] = None
-    group_count: Optional[int] = None
+    percent_complete: EmptyStringNullableInt = None
+    watched_status: EmptyStringNullableFloat = None
+    group_count: EmptyStringNullableInt = None
     group_ids: Optional[str] = None
     state: Optional[Any] = None
     session_key: Optional[Any] = None
 
 
-class HistoryModel(BaseModel):
-    recordsFiltered: Optional[int] = None
-    recordsTotal: Optional[int] = None
+class HistoryModel(_Base):
+    recordsFiltered: EmptyStringNullableInt = None
+    recordsTotal: EmptyStringNullableInt = None
     data: Optional[List[DatumModel]] = None
-    draw: Optional[int] = None
+    draw: EmptyStringNullableInt = None
     filter_duration: Optional[str] = None
     total_duration: Optional[str] = None
 

--- a/tautulli/models/home_stats.py
+++ b/tautulli/models/home_stats.py
@@ -4,42 +4,42 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional, Union
+from typing import List, Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class RowModel(BaseModel):
+class RowModel(_Base):
     title: Optional[str] = None
-    users_watched: Optional[Union[int, str]] = None
-    rating_key: Optional[Union[int, str]] = None
-    last_play: Optional[int] = None
-    total_plays: Optional[int] = None
+    users_watched: EmptyStringNullableInt = None
+    rating_key: EmptyStringNullableInt = None
+    last_play: EmptyStringNullableInt = None
+    total_plays: EmptyStringNullableInt = None
     grandparent_thumb: Optional[str] = None
     thumb: Optional[str] = None
     art: Optional[str] = None
-    section_id: Optional[int] = None
+    section_id: EmptyStringNullableInt = None
     media_type: Optional[str] = None
     content_rating: Optional[str] = None
     labels: Optional[List] = None
     user: Optional[str] = None
     friendly_name: Optional[str] = None
     platform: Optional[str] = None
-    live: Optional[int] = None
+    live: EmptyStringNullableInt = None
     guid: Optional[str] = None
-    row_id: Optional[Union[int, str]] = None
-    total_duration: Optional[int] = None
-    count: Optional[int] = None
+    row_id: EmptyStringNullableInt = None
+    total_duration: EmptyStringNullableInt = None
+    count: EmptyStringNullableInt = None
     started: Optional[str] = None
     stopped: Optional[str] = None
-    user_id: Optional[int] = None
+    user_id: EmptyStringNullableInt = None
     user_thumb: Optional[str] = None
     platform_name: Optional[str] = None
-    last_watch: Optional[int] = None
+    last_watch: EmptyStringNullableInt = None
     player: Optional[str] = None
 
 
-class HomeStatModel(BaseModel):
+class HomeStatModel(_Base):
     stat_id: Optional[str] = None
     stat_title: Optional[str] = None
     rows: Optional[List[RowModel]] = None

--- a/tautulli/models/item_user_stats.py
+++ b/tautulli/models/item_user_stats.py
@@ -4,18 +4,18 @@
 
 from __future__ import annotations
 
-from typing import List, Optional, Any
+from typing import Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class ItemUserStatModel(BaseModel):
+class ItemUserStatModel(_Base):
     friendly_name: Optional[str] = None
-    user_id: Optional[int] = None
+    user_id: EmptyStringNullableInt = None
     user_thumb: Optional[str] = None
     username: Optional[str] = None
-    total_plays: Optional[int] = None
-    total_time: Optional[int] = None
+    total_plays: EmptyStringNullableInt = None
+    total_time: EmptyStringNullableInt = None
 
 
 

--- a/tautulli/models/item_watch_time_stats.py
+++ b/tautulli/models/item_watch_time_stats.py
@@ -4,15 +4,13 @@
 
 from __future__ import annotations
 
-from typing import List, Optional, Any
-
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class ItemWatchTimeStatModel(BaseModel):
-    query_days: Optional[int] = None
-    total_time: Optional[int] = None
-    total_plays: Optional[int] = None
+class ItemWatchTimeStatModel(_Base):
+    query_days: EmptyStringNullableInt = None
+    total_time: EmptyStringNullableInt = None
+    total_plays: EmptyStringNullableInt = None
 
 
 

--- a/tautulli/models/libraries.py
+++ b/tautulli/models/libraries.py
@@ -4,12 +4,12 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class LibrariesEntryModel(BaseModel):
+class LibrariesEntryModel(_Base):
     section_id: Optional[str] = None
     section_name: Optional[str] = None
     section_type: Optional[str] = None
@@ -17,7 +17,7 @@ class LibrariesEntryModel(BaseModel):
     thumb: Optional[str] = None
     art: Optional[str] = None
     count: Optional[str] = None
-    is_active: Optional[int] = None
+    is_active: EmptyStringNullableInt = None
     parent_count: Optional[str] = None
     child_count: Optional[str] = None
 

--- a/tautulli/models/libraries_table.py
+++ b/tautulli/models/libraries_table.py
@@ -4,50 +4,50 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional, Union
+from typing import List, Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class DatumModel(BaseModel):
-    row_id: Optional[int] = None
+class DatumModel(_Base):
+    row_id: EmptyStringNullableInt = None
     server_id: Optional[str] = None
-    section_id: Optional[int] = None
+    section_id: EmptyStringNullableInt = None
     section_name: Optional[str] = None
     section_type: Optional[str] = None
-    count: Optional[int] = None
-    parent_count: Optional[int] = None
-    child_count: Optional[int] = None
+    count: EmptyStringNullableInt = None
+    parent_count: EmptyStringNullableInt = None
+    child_count: EmptyStringNullableInt = None
     library_thumb: Optional[str] = None
     library_art: Optional[str] = None
-    plays: Optional[int] = None
-    duration: Optional[int] = None
-    last_accessed: Optional[int] = None
-    history_row_id: Optional[int] = None
+    plays: EmptyStringNullableInt = None
+    duration: EmptyStringNullableInt = None
+    last_accessed: EmptyStringNullableInt = None
+    history_row_id: EmptyStringNullableInt = None
     last_played: Optional[str] = None
-    rating_key: Optional[int] = None
+    rating_key: EmptyStringNullableInt = None
     media_type: Optional[str] = None
     thumb: Optional[str] = None
     parent_title: Optional[str] = None
-    year: Optional[Union[int, str]] = None
-    media_index: Optional[Union[int, str]] = None
-    parent_media_index: Optional[Union[int, str]] = None
+    year: EmptyStringNullableInt = None
+    media_index: EmptyStringNullableInt = None
+    parent_media_index: EmptyStringNullableInt = None
     content_rating: Optional[str] = None
     labels: Optional[List] = None
-    live: Optional[int] = None
+    live: EmptyStringNullableInt = None
     originally_available_at: Optional[str] = None
     guid: Optional[str] = None
-    do_notify: Optional[int] = None
-    do_notify_created: Optional[int] = None
-    keep_history: Optional[int] = None
-    is_active: Optional[int] = None
+    do_notify: EmptyStringNullableInt = None
+    do_notify_created: EmptyStringNullableInt = None
+    keep_history: EmptyStringNullableInt = None
+    is_active: EmptyStringNullableInt = None
 
 
-class LibrariesTableModel(BaseModel):
-    recordsFiltered: Optional[int] = None
-    recordsTotal: Optional[int] = None
+class LibrariesTableModel(_Base):
+    recordsFiltered: EmptyStringNullableInt = None
+    recordsTotal: EmptyStringNullableInt = None
     data: Optional[List[DatumModel]] = None
-    draw: Optional[int] = None
+    draw: EmptyStringNullableInt = None
 
 
 

--- a/tautulli/models/library.py
+++ b/tautulli/models/library.py
@@ -6,25 +6,25 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class LibraryModel(BaseModel):
-    row_id: Optional[int] = None
+class LibraryModel(_Base):
+    row_id: EmptyStringNullableInt = None
     server_id: Optional[str] = None
-    section_id: Optional[int] = None
+    section_id: EmptyStringNullableInt = None
     section_name: Optional[str] = None
     section_type: Optional[str] = None
     library_thumb: Optional[str] = None
     library_art: Optional[str] = None
-    count: Optional[int] = None
+    count: EmptyStringNullableInt = None
     parent_count: Optional[Any] = None
     child_count: Optional[Any] = None
-    is_active: Optional[int] = None
-    do_notify: Optional[int] = None
-    do_notify_created: Optional[int] = None
-    keep_history: Optional[int] = None
-    deleted_section: Optional[int] = None
+    is_active: EmptyStringNullableInt = None
+    do_notify: EmptyStringNullableInt = None
+    do_notify_created: EmptyStringNullableInt = None
+    keep_history: EmptyStringNullableInt = None
+    deleted_section: EmptyStringNullableInt = None
 
 
 

--- a/tautulli/models/library_media_info.py
+++ b/tautulli/models/library_media_info.py
@@ -4,12 +4,12 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import List, Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class DatumModel(BaseModel):
+class DatumModel(_Base):
     video_resolution: Optional[str] = None
     audio_channels: Optional[str] = None
     container: Optional[str] = None
@@ -19,7 +19,7 @@ class DatumModel(BaseModel):
     bitrate: Optional[str] = None
     video_codec: Optional[str] = None
     section_type: Optional[str] = None
-    section_id: Optional[int] = None
+    section_id: EmptyStringNullableInt = None
     added_at: Optional[str] = None
     sort_title: Optional[str] = None
     file_size: Optional[str] = None
@@ -31,18 +31,18 @@ class DatumModel(BaseModel):
     grandparent_rating_key: Optional[str] = None
     rating_key: Optional[str] = None
     video_framerate: Optional[str] = None
-    last_played: Optional[int] = None
-    play_count: Optional[int] = None
+    last_played: EmptyStringNullableInt = None
+    play_count: EmptyStringNullableInt = None
 
 
-class LibraryMediaInfoModel(BaseModel):
-    recordsFiltered: Optional[int] = None
-    recordsTotal: Optional[int] = None
+class LibraryMediaInfoModel(_Base):
+    recordsFiltered: EmptyStringNullableInt = None
+    recordsTotal: EmptyStringNullableInt = None
     data: Optional[List[DatumModel]] = None
-    draw: Optional[int] = None
-    last_refreshed: Optional[int] = None
-    filtered_file_size: Optional[int] = None
-    total_file_size: Optional[int] = None
+    draw: EmptyStringNullableInt = None
+    last_refreshed: EmptyStringNullableInt = None
+    filtered_file_size: EmptyStringNullableInt = None
+    total_file_size: EmptyStringNullableInt = None
 
 
 

--- a/tautulli/models/library_names.py
+++ b/tautulli/models/library_names.py
@@ -4,13 +4,13 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class LibraryNameModel(BaseModel):
-    section_id: Optional[int] = None
+class LibraryNameModel(_Base):
+    section_id: EmptyStringNullableInt = None
     section_name: Optional[str] = None
     section_type: Optional[str] = None
     agent: Optional[str] = None

--- a/tautulli/models/library_user_stats.py
+++ b/tautulli/models/library_user_stats.py
@@ -4,17 +4,17 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class LibraryUserStatsModel(BaseModel):
+class LibraryUserStatsModel(_Base):
     friendly_name: Optional[str] = None
-    user_id: Optional[int] = None
+    user_id: EmptyStringNullableInt = None
     user_thumb: Optional[str] = None
     username: Optional[str] = None
-    total_plays: Optional[int] = None
+    total_plays: EmptyStringNullableInt = None
 
 
 

--- a/tautulli/models/library_watch_time_stats.py
+++ b/tautulli/models/library_watch_time_stats.py
@@ -4,15 +4,13 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
-
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class LibraryWatchTimeStatsModel(BaseModel):
-    query_days: Optional[int] = None
-    total_time: Optional[int] = None
-    total_plays: Optional[int] = None
+class LibraryWatchTimeStatsModel(_Base):
+    query_days: EmptyStringNullableInt = None
+    total_time: EmptyStringNullableInt = None
+    total_plays: EmptyStringNullableInt = None
 
 
 

--- a/tautulli/models/logs.py
+++ b/tautulli/models/logs.py
@@ -4,12 +4,12 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base
 
 
-class LogEntryModel(BaseModel):
+class LogEntryModel(_Base):
     time: Optional[str] = None
     loglevel: Optional[str] = None
     msg: Optional[str] = None

--- a/tautulli/models/metadata.py
+++ b/tautulli/models/metadata.py
@@ -4,12 +4,12 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import List, Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt, EmptyStringNullableFloat
 
 
-class StreamModel(BaseModel):
+class StreamModel(_Base):
     id: Optional[str] = None
     type: Optional[str] = None
     video_codec: Optional[str] = None
@@ -22,13 +22,13 @@ class StreamModel(BaseModel):
     video_color_space: Optional[str] = None
     video_color_trc: Optional[str] = None
     video_dynamic_range: Optional[str] = None
-    video_dovi_bl_present: Optional[int] = None
-    video_dovi_el_present: Optional[int] = None
-    video_dovi_level: Optional[int] = None
-    video_dovi_present: Optional[int] = None
-    video_dovi_profile: Optional[int] = None
-    video_dovi_rpu_present: Optional[int] = None
-    video_dovi_version: Optional[float] = None
+    video_dovi_bl_present: EmptyStringNullableInt = None
+    video_dovi_el_present: EmptyStringNullableInt = None
+    video_dovi_level: EmptyStringNullableInt = None
+    video_dovi_present: EmptyStringNullableInt = None
+    video_dovi_profile: EmptyStringNullableInt = None
+    video_dovi_rpu_present: EmptyStringNullableInt = None
+    video_dovi_version: EmptyStringNullableFloat = None
     video_frame_rate: Optional[str] = None
     video_ref_frames: Optional[str] = None
     video_height: Optional[str] = None
@@ -37,7 +37,7 @@ class StreamModel(BaseModel):
     video_language_code: Optional[str] = None
     video_profile: Optional[str] = None
     video_scan_type: Optional[str] = None
-    selected: Optional[int] = None
+    selected: EmptyStringNullableInt = None
     audio_codec: Optional[str] = None
     audio_bitrate: Optional[str] = None
     audio_bitrate_mode: Optional[str] = None
@@ -49,16 +49,16 @@ class StreamModel(BaseModel):
     audio_profile: Optional[str] = None
 
 
-class PartModel(BaseModel):
+class PartModel(_Base):
     id: Optional[str] = None
     file: Optional[str] = None
     file_size: Optional[str] = None
-    indexes: Optional[int] = None
+    indexes: EmptyStringNullableInt = None
     streams: Optional[List[StreamModel]] = None
-    selected: Optional[int] = None
+    selected: EmptyStringNullableInt = None
 
 
-class MediaInfoItemModel(BaseModel):
+class MediaInfoItemModel(_Base):
     id: Optional[str] = None
     container: Optional[str] = None
     bitrate: Optional[str] = None
@@ -74,7 +74,7 @@ class MediaInfoItemModel(BaseModel):
     audio_channels: Optional[str] = None
     audio_channel_layout: Optional[str] = None
     audio_profile: Optional[str] = None
-    optimized_version: Optional[int] = None
+    optimized_version: EmptyStringNullableInt = None
     channel_call_sign: Optional[str] = None
     channel_id: Optional[str] = None
     channel_identifier: Optional[str] = None
@@ -84,16 +84,16 @@ class MediaInfoItemModel(BaseModel):
     parts: Optional[List[PartModel]] = None
 
 
-class MarkerModel(BaseModel):
-    id: Optional[int] = None
+class MarkerModel(_Base):
+    id: EmptyStringNullableInt = None
     type: Optional[str] = None
-    start_time_offset: Optional[int] = None
-    end_time_offset: Optional[int] = None
+    start_time_offset: EmptyStringNullableInt = None
+    end_time_offset: EmptyStringNullableInt = None
     first: Optional[bool] = None
     final: Optional[bool] = None
 
 
-class MetadataModel(BaseModel):
+class MetadataModel(_Base):
     media_type: Optional[str] = None
     section_id: Optional[str] = None
     library_name: Optional[str] = None
@@ -143,8 +143,8 @@ class MetadataModel(BaseModel):
     collections: Optional[List] = None
     guids: Optional[List[str]] = None
     full_title: Optional[str] = None
-    children_count: Optional[int] = None
-    live: Optional[int] = None
+    children_count: EmptyStringNullableInt = None
+    live: EmptyStringNullableInt = None
     media_info: Optional[List[MediaInfoItemModel]] = None
     edition_title: Optional[str] = None
     markers: Optional[List[MarkerModel]] = None

--- a/tautulli/models/new_rating_keys.py
+++ b/tautulli/models/new_rating_keys.py
@@ -4,16 +4,16 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Optional
 
-from pydantic import BaseModel, Field
-
-
-class Field0Model(BaseModel):
-    rating_key: Optional[int] = None
+from tautulli.models._base import _Base, Field, EmptyStringNullableInt
 
 
-class NewRatingKeysModel(BaseModel):
+class Field0Model(_Base):
+    rating_key: EmptyStringNullableInt = None
+
+
+class NewRatingKeysModel(_Base):
     field_0: Optional[Field0Model] = Field(..., alias='0')
 
 

--- a/tautulli/models/newsletter.py
+++ b/tautulli/models/newsletter.py
@@ -4,16 +4,16 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class NewsletterModel(BaseModel):
-    id: Optional[int] = None
-    agent_id: Optional[int] = None
+class NewsletterModel(_Base):
+    id: EmptyStringNullableInt = None
+    agent_id: EmptyStringNullableInt = None
     agent_name: Optional[str] = None
     agent_label: Optional[str] = None
     friendly_name: Optional[str] = None
     cron: Optional[str] = None
-    active: Optional[int] = None
+    active: EmptyStringNullableInt = None

--- a/tautulli/models/newsletter_config.py
+++ b/tautulli/models/newsletter_config.py
@@ -6,57 +6,57 @@ from __future__ import annotations
 
 from typing import List, Optional, Union
 
-from pydantic import BaseModel, Field
+from tautulli.models._base import _Base, Field, EmptyStringNullableInt
 
 
-class ConfigModel(BaseModel):
-    custom_cron: Optional[int] = None
-    time_frame: Optional[int] = None
+class ConfigModel(_Base):
+    custom_cron: EmptyStringNullableInt = None
+    time_frame: EmptyStringNullableInt = None
     time_frame_units: Optional[str] = None
-    formatted: Optional[int] = None
-    threaded: Optional[int] = None
-    notifier_id: Optional[int] = None
+    formatted: EmptyStringNullableInt = None
+    threaded: EmptyStringNullableInt = None
+    notifier_id: EmptyStringNullableInt = None
     filename: Optional[str] = None
-    save_only: Optional[int] = None
+    save_only: EmptyStringNullableInt = None
     incl_libraries: Optional[List[str]] = None
 
 
-class EmailConfigModel(BaseModel):
+class EmailConfigModel(_Base):
     from_name: Optional[str] = None
     from_: Optional[str] = Field(..., alias='from')
     to: Optional[List[str]] = None
     cc: Optional[List] = None
     bcc: Optional[List] = None
     smtp_server: Optional[str] = None
-    smtp_port: Optional[int] = None
+    smtp_port: EmptyStringNullableInt = None
     smtp_user: Optional[str] = None
     smtp_password: Optional[str] = None
-    tls: Optional[int] = None
-    html_support: Optional[int] = None
-    notifier_id: Optional[int] = None
+    tls: EmptyStringNullableInt = None
+    html_support: EmptyStringNullableInt = None
+    notifier_id: EmptyStringNullableInt = None
 
 
-class MovieLibraryModel(BaseModel):
-    value: Optional[int] = None
+class MovieLibraryModel(_Base):
+    value: EmptyStringNullableInt = None
     text: Optional[str] = None
 
 
-class TVShowLibraryModel(BaseModel):
-    value: Optional[int] = None
+class TVShowLibraryModel(_Base):
+    value: EmptyStringNullableInt = None
     text: Optional[str] = None
 
 
-class MusicLibraryModel(BaseModel):
-    value: Optional[int] = None
+class MusicLibraryModel(_Base):
+    value: EmptyStringNullableInt = None
     text: Optional[str] = None
 
 
-class OtherVideoLibraryModel(BaseModel):
-    value: Optional[int] = None
+class OtherVideoLibraryModel(_Base):
+    value: EmptyStringNullableInt = None
     text: Optional[str] = None
 
 
-class SelectOptionsModel(BaseModel):
+class SelectOptionsModel(_Base):
     Movie_Libraries: Optional[List[MovieLibraryModel]] = Field(..., alias='Movie Libraries')
     TV_Show_Libraries: Optional[List[TVShowLibraryModel]] = Field(..., alias='TV Show Libraries')
     Music_Libraries: Optional[List[MusicLibraryModel]] = Field(..., alias='Music Libraries')
@@ -65,7 +65,7 @@ class SelectOptionsModel(BaseModel):
     )
 
 
-class ConfigOptionModel(BaseModel):
+class ConfigOptionModel(_Base):
     label: Optional[str] = None
     value: Optional[List[str]] = None
     description: Optional[str] = None
@@ -74,12 +74,12 @@ class ConfigOptionModel(BaseModel):
     select_options: Optional[SelectOptionsModel] = None
 
 
-class SelectOptionModel(BaseModel):
+class SelectOptionModel(_Base):
     value: Optional[str] = None
     text: Optional[str] = None
 
 
-class EmailConfigOptionModel(BaseModel):
+class EmailConfigOptionModel(_Base):
     label: Optional[str] = None
     value: Optional[Union[Union[int, str], List[str]]] = None
     name: Optional[str] = None
@@ -88,14 +88,14 @@ class EmailConfigOptionModel(BaseModel):
     select_options: Optional[List[SelectOptionModel]] = None
 
 
-class NewsletterConfigModel(BaseModel):
-    id: Optional[int] = None
-    agent_id: Optional[int] = None
+class NewsletterConfigModel(_Base):
+    id: EmptyStringNullableInt = None
+    agent_id: EmptyStringNullableInt = None
     agent_name: Optional[str] = None
     agent_label: Optional[str] = None
     friendly_name: Optional[str] = None
     cron: Optional[str] = None
-    active: Optional[int] = None
+    active: EmptyStringNullableInt = None
     id_name: Optional[str] = None
     subject: Optional[str] = None
     body: Optional[str] = None

--- a/tautulli/models/newsletter_log.py
+++ b/tautulli/models/newsletter_log.py
@@ -4,16 +4,16 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import List, Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class DatumModel(BaseModel):
-    id: Optional[int] = None
-    timestamp: Optional[int] = None
-    newsletter_id: Optional[int] = None
-    agent_id: Optional[int] = None
+class DatumModel(_Base):
+    id: EmptyStringNullableInt = None
+    timestamp: EmptyStringNullableInt = None
+    newsletter_id: EmptyStringNullableInt = None
+    agent_id: EmptyStringNullableInt = None
     agent_name: Optional[str] = None
     notify_action: Optional[str] = None
     subject_text: Optional[str] = None
@@ -21,14 +21,14 @@ class DatumModel(BaseModel):
     start_date: Optional[str] = None
     end_date: Optional[str] = None
     uuid: Optional[str] = None
-    success: Optional[int] = None
+    success: EmptyStringNullableInt = None
 
 
-class NewsletterLogModel(BaseModel):
-    recordsFiltered: Optional[int] = None
-    recordsTotal: Optional[int] = None
+class NewsletterLogModel(_Base):
+    recordsFiltered: EmptyStringNullableInt = None
+    recordsTotal: EmptyStringNullableInt = None
     data: Optional[List[DatumModel]] = None
-    draw: Optional[int] = None
+    draw: EmptyStringNullableInt = None
 
 
 

--- a/tautulli/models/newsletter_notification.py
+++ b/tautulli/models/newsletter_notification.py
@@ -4,13 +4,11 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
-
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class NewsletterNotificationModel(BaseModel):
-    newsletter_notification_id: Optional[int] = None
+class NewsletterNotificationModel(_Base):
+    newsletter_notification_id: EmptyStringNullableInt = None
 
 
 

--- a/tautulli/models/notification.py
+++ b/tautulli/models/notification.py
@@ -4,13 +4,11 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
-
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class NotificationModel(BaseModel):
-    notification_id: Optional[int] = None
+class NotificationModel(_Base):
+    notification_id: EmptyStringNullableInt = None
 
 
 

--- a/tautulli/models/notification_log.py
+++ b/tautulli/models/notification_log.py
@@ -4,32 +4,32 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import List, Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class DatumModel(BaseModel):
-    id: Optional[int] = None
-    timestamp: Optional[int] = None
-    session_key: Optional[int] = None
-    rating_key: Optional[int] = None
-    user_id: Optional[int] = None
+class DatumModel(_Base):
+    id: EmptyStringNullableInt = None
+    timestamp: EmptyStringNullableInt = None
+    session_key: EmptyStringNullableInt = None
+    rating_key: EmptyStringNullableInt = None
+    user_id: EmptyStringNullableInt = None
     user: Optional[str] = None
-    notifier_id: Optional[int] = None
-    agent_id: Optional[int] = None
+    notifier_id: EmptyStringNullableInt = None
+    agent_id: EmptyStringNullableInt = None
     agent_name: Optional[str] = None
     notify_action: Optional[str] = None
     subject_text: Optional[str] = None
     body_text: Optional[str] = None
-    success: Optional[int] = None
+    success: EmptyStringNullableInt = None
 
 
-class NotificationLogModel(BaseModel):
-    recordsFiltered: Optional[int] = None
-    recordsTotal: Optional[int] = None
+class NotificationLogModel(_Base):
+    recordsFiltered: EmptyStringNullableInt = None
+    recordsTotal: EmptyStringNullableInt = None
     data: Optional[List[DatumModel]] = None
-    draw: Optional[int] = None
+    draw: EmptyStringNullableInt = None
 
 
 

--- a/tautulli/models/notifier_config.py
+++ b/tautulli/models/notifier_config.py
@@ -6,41 +6,41 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class ConfigModel(BaseModel):
-    incl_poster: Optional[int] = None
-    html_support: Optional[int] = None
+class ConfigModel(_Base):
+    incl_poster: EmptyStringNullableInt = None
+    html_support: EmptyStringNullableInt = None
     chat_id: Optional[str] = None
     bot_token: Optional[str] = None
-    incl_subject: Optional[int] = None
-    disable_web_preview: Optional[int] = None
+    incl_subject: EmptyStringNullableInt = None
+    disable_web_preview: EmptyStringNullableInt = None
 
 
-class ActionsModel(BaseModel):
-    on_play: Optional[int] = None
-    on_stop: Optional[int] = None
+class ActionsModel(_Base):
+    on_play: EmptyStringNullableInt = None
+    on_stop: EmptyStringNullableInt = None
 
 
-class OnPlayModel(BaseModel):
+class OnPlayModel(_Base):
     subject: Optional[str] = None
     body: Optional[str] = None
 
 
-class OnStopModel(BaseModel):
+class OnStopModel(_Base):
     subject: Optional[str] = None
     body: Optional[str] = None
 
 
-class NotifyTextModel(BaseModel):
+class NotifyTextModel(_Base):
     on_play: Optional[OnPlayModel] = None
     on_stop: Optional[OnStopModel] = None
 
 
-class NotifierConfigModel(BaseModel):
-    id: Optional[int] = None
-    agent_id: Optional[int] = None
+class NotifierConfigModel(_Base):
+    id: EmptyStringNullableInt = None
+    agent_id: EmptyStringNullableInt = None
     agent_name: Optional[str] = None
     agent_label: Optional[str] = None
     friendly_name: Optional[str] = None

--- a/tautulli/models/notifier_parameters.py
+++ b/tautulli/models/notifier_parameters.py
@@ -4,12 +4,12 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base
 
 
-class NotifierParameterModel(BaseModel):
+class NotifierParameterModel(_Base):
     name: Optional[str] = None
     type: Optional[str] = None
     value: Optional[str] = None

--- a/tautulli/models/notifiers.py
+++ b/tautulli/models/notifiers.py
@@ -4,18 +4,18 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class NotifierModel(BaseModel):
-    id: Optional[int] = None
-    agent_id: Optional[int] = None
+class NotifierModel(_Base):
+    id: EmptyStringNullableInt = None
+    agent_id: EmptyStringNullableInt = None
     agent_name: Optional[str] = None
     agent_label: Optional[str] = None
     friendly_name: Optional[str] = None
-    active: Optional[int] = None
+    active: EmptyStringNullableInt = None
 
 
 

--- a/tautulli/models/old_rating_keys.py
+++ b/tautulli/models/old_rating_keys.py
@@ -4,16 +4,16 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Optional
 
-from pydantic import BaseModel, Field
-
-
-class Field0Model(BaseModel):
-    rating_key: Optional[int] = None
+from tautulli.models._base import _Base, Field, EmptyStringNullableInt
 
 
-class OldRatingKeysModel(BaseModel):
+class Field0Model(_Base):
+    rating_key: EmptyStringNullableInt = None
+
+
+class OldRatingKeysModel(_Base):
     field_0: Optional[Field0Model] = Field(..., alias='0')
 
 

--- a/tautulli/models/playlists_table.py
+++ b/tautulli/models/playlists_table.py
@@ -6,18 +6,18 @@ from __future__ import annotations
 
 from typing import Any, List, Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class DatumModel(BaseModel):
+class DatumModel(_Base):
     addedAt: Optional[str] = None
     composite: Optional[str] = None
-    duration: Optional[int] = None
+    duration: EmptyStringNullableInt = None
     guid: Optional[str] = None
-    leafCount: Optional[int] = None
+    leafCount: EmptyStringNullableInt = None
     librarySectionID: Optional[str] = None
     playlistType: Optional[str] = None
-    ratingKey: Optional[int] = None
+    ratingKey: EmptyStringNullableInt = None
     smart: Optional[bool] = None
     summary: Optional[str] = None
     title: Optional[str] = None
@@ -26,11 +26,11 @@ class DatumModel(BaseModel):
     userID: Optional[Any] = None
 
 
-class PlaylistsTableModel(BaseModel):
-    recordsFiltered: Optional[int] = None
-    recordsTotal: Optional[int] = None
+class PlaylistsTableModel(_Base):
+    recordsFiltered: EmptyStringNullableInt = None
+    recordsTotal: EmptyStringNullableInt = None
     data: Optional[List[DatumModel]] = None
-    draw: Optional[int] = None
+    draw: EmptyStringNullableInt = None
 
 
 

--- a/tautulli/models/plex_log.py
+++ b/tautulli/models/plex_log.py
@@ -4,12 +4,12 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import List, Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base
 
 
-class PlexLogModel(BaseModel):
+class PlexLogModel(_Base):
     data: Optional[List] = None
 
 

--- a/tautulli/models/pms_update.py
+++ b/tautulli/models/pms_update.py
@@ -4,15 +4,15 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class PMSUpdateModel(BaseModel):
+class PMSUpdateModel(_Base):
     update_available: Optional[bool] = None
     platform: Optional[str] = None
-    release_date: Optional[int] = None
+    release_date: EmptyStringNullableInt = None
     version: Optional[str] = None
     requirements: Optional[str] = None
     extra_info: Optional[str] = None

--- a/tautulli/models/recently_added.py
+++ b/tautulli/models/recently_added.py
@@ -4,12 +4,12 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import List, Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base
 
 
-class RecentlyAddedItemModel(BaseModel):
+class RecentlyAddedItemModel(_Base):
     media_type: str
     section_id: str
     library_name: str
@@ -55,7 +55,7 @@ class RecentlyAddedItemModel(BaseModel):
     child_count: str
 
 
-class RecentlyAddedModel(BaseModel):
+class RecentlyAddedModel(_Base):
     recently_added: Optional[List[RecentlyAddedItemModel]] = None
 
 

--- a/tautulli/models/registered_device.py
+++ b/tautulli/models/registered_device.py
@@ -6,23 +6,23 @@ from __future__ import annotations
 
 from typing import Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class RegisteredDeviceModel(BaseModel):
+class RegisteredDeviceModel(_Base):
     server_id: Optional[str] = None
     pms_name: Optional[str] = None
     pms_version: Optional[str] = None
     pms_platform: Optional[str] = None
     pms_ip: Optional[str] = None
-    pms_port: Optional[int] = None
-    pms_ssl: Optional[int] = None
-    pms_is_remote: Optional[int] = None
-    pms_is_cloud: Optional[int] = None
+    pms_port: EmptyStringNullableInt = None
+    pms_ssl: EmptyStringNullableInt = None
+    pms_is_remote: EmptyStringNullableInt = None
+    pms_is_cloud: EmptyStringNullableInt = None
     pms_url: Optional[str] = None
-    pms_url_manual: Optional[int] = None
+    pms_url_manual: EmptyStringNullableInt = None
     pms_identifier: Optional[str] = None
-    pms_plexpass: Optional[int] = None
+    pms_plexpass: EmptyStringNullableInt = None
     tautulli_install_type: Optional[str] = None
     tautulli_version: Optional[str] = None
     tautulli_branch: Optional[str] = None

--- a/tautulli/models/search_results.py
+++ b/tautulli/models/search_results.py
@@ -4,12 +4,12 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import List, Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class StreamModel(BaseModel):
+class StreamModel(_Base):
     id: Optional[str] = None
     type: Optional[str] = None
     video_codec: Optional[str] = None
@@ -29,7 +29,7 @@ class StreamModel(BaseModel):
     video_language_code: Optional[str] = None
     video_profile: Optional[str] = None
     video_scan_type: Optional[str] = None
-    selected: Optional[int] = None
+    selected: EmptyStringNullableInt = None
     audio_codec: Optional[str] = None
     audio_bitrate: Optional[str] = None
     audio_bitrate_mode: Optional[str] = None
@@ -42,22 +42,22 @@ class StreamModel(BaseModel):
     subtitle_codec: Optional[str] = None
     subtitle_container: Optional[str] = None
     subtitle_format: Optional[str] = None
-    subtitle_forced: Optional[int] = None
+    subtitle_forced: EmptyStringNullableInt = None
     subtitle_location: Optional[str] = None
     subtitle_language: Optional[str] = None
     subtitle_language_code: Optional[str] = None
 
 
-class PartModel(BaseModel):
+class PartModel(_Base):
     id: Optional[str] = None
     file: Optional[str] = None
     file_size: Optional[str] = None
-    indexes: Optional[int] = None
+    indexes: EmptyStringNullableInt = None
     streams: Optional[List[StreamModel]] = None
-    selected: Optional[int] = None
+    selected: EmptyStringNullableInt = None
 
 
-class MediaInfoItemModel(BaseModel):
+class MediaInfoItemModel(_Base):
     id: Optional[str] = None
     container: Optional[str] = None
     bitrate: Optional[str] = None
@@ -73,14 +73,14 @@ class MediaInfoItemModel(BaseModel):
     audio_channels: Optional[str] = None
     audio_channel_layout: Optional[str] = None
     audio_profile: Optional[str] = None
-    optimized_version: Optional[int] = None
+    optimized_version: EmptyStringNullableInt = None
     channel_call_sign: Optional[str] = None
     channel_identifier: Optional[str] = None
     channel_thumb: Optional[str] = None
     parts: Optional[List[PartModel]] = None
 
 
-class MovieItemModel(BaseModel):
+class MovieItemModel(_Base):
     media_type: Optional[str] = None
     section_id: Optional[str] = None
     library_name: Optional[str] = None
@@ -125,12 +125,12 @@ class MovieItemModel(BaseModel):
     collections: Optional[List] = None
     guids: Optional[List] = None
     full_title: Optional[str] = None
-    children_count: Optional[int] = None
-    live: Optional[int] = None
+    children_count: EmptyStringNullableInt = None
+    live: EmptyStringNullableInt = None
     media_info: Optional[List[MediaInfoItemModel]] = None
 
 
-class ShowItemModel(BaseModel):
+class ShowItemModel(_Base):
     media_type: Optional[str] = None
     section_id: Optional[str] = None
     library_name: Optional[str] = None
@@ -175,12 +175,12 @@ class ShowItemModel(BaseModel):
     collections: Optional[List] = None
     guids: Optional[List] = None
     full_title: Optional[str] = None
-    children_count: Optional[int] = None
-    live: Optional[int] = None
+    children_count: EmptyStringNullableInt = None
+    live: EmptyStringNullableInt = None
     media_info: Optional[List] = None
 
 
-class SeasonItemModel(BaseModel):
+class SeasonItemModel(_Base):
     media_type: Optional[str] = None
     section_id: Optional[str] = None
     library_name: Optional[str] = None
@@ -225,12 +225,12 @@ class SeasonItemModel(BaseModel):
     collections: Optional[List] = None
     guids: Optional[List] = None
     full_title: Optional[str] = None
-    children_count: Optional[int] = None
-    live: Optional[int] = None
+    children_count: EmptyStringNullableInt = None
+    live: EmptyStringNullableInt = None
     media_info: Optional[List] = None
 
 
-class EpisodeItemModel(BaseModel):
+class EpisodeItemModel(_Base):
     media_type: Optional[str] = None
     section_id: Optional[str] = None
     library_name: Optional[str] = None
@@ -275,12 +275,12 @@ class EpisodeItemModel(BaseModel):
     collections: Optional[List] = None
     guids: Optional[List] = None
     full_title: Optional[str] = None
-    children_count: Optional[int] = None
-    live: Optional[int] = None
+    children_count: EmptyStringNullableInt = None
+    live: EmptyStringNullableInt = None
     media_info: Optional[List[MediaInfoItemModel]] = None
 
 
-class ResultsListModel(BaseModel):
+class ResultsListModel(_Base):
     movie: Optional[List[MovieItemModel]] = None
     show: Optional[List[ShowItemModel]] = None
     season: Optional[List[SeasonItemModel]] = None
@@ -291,8 +291,8 @@ class ResultsListModel(BaseModel):
     collection: Optional[List] = None
 
 
-class SearchResultsModel(BaseModel):
-    results_count: Optional[int] = None
+class SearchResultsModel(_Base):
+    results_count: EmptyStringNullableInt = None
     results_list: Optional[ResultsListModel] = None
 
 

--- a/tautulli/models/server_id.py
+++ b/tautulli/models/server_id.py
@@ -6,10 +6,10 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base
 
 
-class ServerIDModel(BaseModel):
+class ServerIDModel(_Base):
     identifier: Optional[Any] = None
 
 

--- a/tautulli/models/server_identity.py
+++ b/tautulli/models/server_identity.py
@@ -4,11 +4,11 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base
 
 
-class ServerIdentityModel(BaseModel):
+class ServerIdentityModel(_Base):
     machine_identifier: Optional[str] = None
     version: Optional[str] = None

--- a/tautulli/models/server_info.py
+++ b/tautulli/models/server_info.py
@@ -4,23 +4,23 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class ServerInfoModel(BaseModel):
+class ServerInfoModel(_Base):
     pms_name: Optional[str] = None
     pms_version: Optional[str] = None
     pms_platform: Optional[str] = None
     pms_ip: Optional[str] = None
-    pms_port: Optional[int] = None
-    pms_ssl: Optional[int] = None
-    pms_is_remote: Optional[int] = None
+    pms_port: EmptyStringNullableInt = None
+    pms_ssl: EmptyStringNullableInt = None
+    pms_is_remote: EmptyStringNullableInt = None
     pms_url: Optional[str] = None
-    pms_url_manual: Optional[int] = None
+    pms_url_manual: EmptyStringNullableInt = None
     pms_identifier: Optional[str] = None
-    pms_plexpass: Optional[int] = None
+    pms_plexpass: EmptyStringNullableInt = None
 
 
 

--- a/tautulli/models/server_list.py
+++ b/tautulli/models/server_list.py
@@ -4,12 +4,12 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base
 
 
-class ServerListEntryModel(BaseModel):
+class ServerListEntryModel(_Base):
     httpsRequired: Optional[str] = None
     clientIdentifier: Optional[str] = None
     label: Optional[str] = None

--- a/tautulli/models/server_status.py
+++ b/tautulli/models/server_status.py
@@ -4,12 +4,12 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base
 
 
-class ServerStatusModel(BaseModel):
+class ServerStatusModel(_Base):
     result: Optional[str] = None
     connected: Optional[bool] = None
 

--- a/tautulli/models/servers_info.py
+++ b/tautulli/models/servers_info.py
@@ -6,10 +6,10 @@ from __future__ import annotations
 
 from typing import Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base
 
 
-class ServersInfoEntryModel(BaseModel):
+class ServersInfoEntryModel(_Base):
     name: Optional[str] = None
     machine_identifier: Optional[str] = None
     host: Optional[str] = None

--- a/tautulli/models/settings.py
+++ b/tautulli/models/settings.py
@@ -4,12 +4,12 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import List, Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class IFTTTModel(BaseModel):
+class IFTTTModel(_Base):
     ifttt_on_stop: Optional[bool] = None
     ifttt_on_pause: Optional[bool] = None
     ifttt_key: Optional[str] = None
@@ -29,7 +29,7 @@ class IFTTTModel(BaseModel):
     ifttt_on_play: Optional[bool] = None
 
 
-class GrowlModel(BaseModel):
+class GrowlModel(_Base):
     growl_enabled: Optional[bool] = None
     growl_on_play: Optional[bool] = None
     growl_on_stop: Optional[bool] = None
@@ -49,7 +49,7 @@ class GrowlModel(BaseModel):
     growl_on_extdown: Optional[bool] = None
 
 
-class PMSModel(BaseModel):
+class PMSModel(_Base):
     pms_use_bif: Optional[bool] = None
     pms_uuid: Optional[str] = None
     pms_url: Optional[str] = None
@@ -57,32 +57,32 @@ class PMSModel(BaseModel):
     pms_update_distro: Optional[str] = None
     pms_name: Optional[str] = None
     pms_logs_folder: Optional[str] = None
-    pms_plexpass: Optional[int] = None
+    pms_plexpass: EmptyStringNullableInt = None
     pms_token: Optional[str] = None
-    pms_port: Optional[int] = None
-    pms_is_remote: Optional[int] = None
+    pms_port: EmptyStringNullableInt = None
+    pms_is_remote: EmptyStringNullableInt = None
     pms_identifier: Optional[str] = None
-    pms_ssl: Optional[int] = None
+    pms_ssl: EmptyStringNullableInt = None
     pms_version: Optional[str] = None
     pms_update_distro_build: Optional[str] = None
     pms_ip: Optional[str] = None
-    pms_logs_line_cap: Optional[int] = None
+    pms_logs_line_cap: EmptyStringNullableInt = None
     pms_platform: Optional[str] = None
-    pms_url_manual: Optional[int] = None
+    pms_url_manual: EmptyStringNullableInt = None
     pms_web_url: Optional[str] = None
-    pms_is_cloud: Optional[int] = None
+    pms_is_cloud: EmptyStringNullableInt = None
     pms_url_override: Optional[str] = None
 
 
-class MonitoringModel(BaseModel):
-    notify_upload_posters: Optional[int] = None
+class MonitoringModel(_Base):
+    notify_upload_posters: EmptyStringNullableInt = None
     movie_notify_enable: Optional[bool] = None
     notify_on_resume_body_text: Optional[str] = None
     notify_on_pmsupdate_body_text: Optional[str] = None
     refresh_libraries_on_startup: Optional[bool] = None
-    session_db_write_attempts: Optional[int] = None
+    session_db_write_attempts: EmptyStringNullableInt = None
     notify_on_created_body_text: Optional[str] = None
-    buffer_wait: Optional[int] = None
+    buffer_wait: EmptyStringNullableInt = None
     notify_on_intup_subject_text: Optional[str] = None
     notify_recently_added_grandparent: Optional[bool] = None
     notify_on_newdevice_subject_text: Optional[str] = None
@@ -103,16 +103,16 @@ class MonitoringModel(BaseModel):
     notify_scripts_args_text: Optional[str] = None
     music_logging_enable: Optional[bool] = None
     movie_notify_on_stop: Optional[bool] = None
-    notify_watched_percent: Optional[int] = None
+    notify_watched_percent: EmptyStringNullableInt = None
     notify_on_concurrent_subject_text: Optional[str] = None
     notify_on_concurrent_body_text: Optional[str] = None
     tv_logging_enable: Optional[bool] = None
     tv_notify_enable: Optional[bool] = None
-    notify_recently_added_delay: Optional[int] = None
+    notify_recently_added_delay: EmptyStringNullableInt = None
     notify_on_intdown_body_text: Optional[str] = None
-    logging_ignore_interval: Optional[int] = None
+    logging_ignore_interval: EmptyStringNullableInt = None
     notify_on_newdevice_body_text: Optional[str] = None
-    refresh_users_interval: Optional[int] = None
+    refresh_users_interval: EmptyStringNullableInt = None
     monitoring_use_websocket: Optional[bool] = None
     monitor_pms_updates: Optional[bool] = None
     notify_on_start_subject_text: Optional[str] = None
@@ -122,13 +122,13 @@ class MonitoringModel(BaseModel):
     movie_notify_on_start: Optional[bool] = None
     notify_concurrent_by_ip: Optional[bool] = None
     refresh_users_on_startup: Optional[bool] = None
-    buffer_threshold: Optional[int] = None
+    buffer_threshold: EmptyStringNullableInt = None
     notify_on_extdown_subject_text: Optional[str] = None
-    refresh_libraries_interval: Optional[int] = None
+    refresh_libraries_interval: EmptyStringNullableInt = None
     tv_notify_on_start: Optional[bool] = None
     video_logging_enable: Optional[bool] = None
     notify_on_resume_subject_text: Optional[str] = None
-    notify_concurrent_threshold: Optional[int] = None
+    notify_concurrent_threshold: EmptyStringNullableInt = None
     notify_on_stop_subject_text: Optional[str] = None
     movie_notify_on_pause: Optional[bool] = None
     notify_consecutive: Optional[bool] = None
@@ -139,31 +139,31 @@ class MonitoringModel(BaseModel):
     tv_notify_on_pause: Optional[bool] = None
     monitor_remote_access: Optional[bool] = None
     imgur_client_id: Optional[str] = None
-    monitoring_interval: Optional[int] = None
+    monitoring_interval: EmptyStringNullableInt = None
     notify_on_buffer_subject_text: Optional[str] = None
-    tv_watched_percent: Optional[int] = None
+    tv_watched_percent: EmptyStringNullableInt = None
     notify_group_recently_added_grandparent: Optional[bool] = None
     notify_recently_added_upgrade: Optional[bool] = None
     notify_group_recently_added: Optional[bool] = None
     notify_group_recently_added_parent: Optional[bool] = None
-    movie_watched_percent: Optional[int] = None
-    music_watched_percent: Optional[int] = None
-    notify_continued_session_threshold: Optional[int] = None
-    notify_remote_access_threshold: Optional[int] = None
+    movie_watched_percent: EmptyStringNullableInt = None
+    music_watched_percent: EmptyStringNullableInt = None
+    notify_continued_session_threshold: EmptyStringNullableInt = None
+    notify_remote_access_threshold: EmptyStringNullableInt = None
     notify_new_device_initial_only: Optional[bool] = None
 
 
-class GetFileSizesHoldModel(BaseModel):
+class GetFileSizesHoldModel(_Base):
     section_ids: Optional[List] = None
     rating_keys: Optional[List] = None
 
 
-class GeneralModel(BaseModel):
+class GeneralModel(_Base):
     week_start_monday: Optional[bool] = None
     git_token: Optional[str] = None
     home_stats_cards: Optional[List[str]] = None
-    backup_interval: Optional[int] = None
-    graph_days: Optional[int] = None
+    backup_interval: EmptyStringNullableInt = None
+    graph_days: EmptyStringNullableInt = None
     graph_type: Optional[str] = None
     get_file_sizes: Optional[bool] = None
     http_basic_auth: Optional[bool] = None
@@ -185,7 +185,7 @@ class GeneralModel(BaseModel):
     git_path: Optional[str] = None
     update_labels: Optional[bool] = None
     config_version: Optional[str] = None
-    check_github_interval: Optional[int] = None
+    check_github_interval: EmptyStringNullableInt = None
     https_ip: Optional[str] = None
     group_history_tables: Optional[bool] = None
     https_domain: Optional[str] = None
@@ -201,14 +201,14 @@ class GeneralModel(BaseModel):
     graph_months: Optional[str] = None
     cleanup_files: Optional[bool] = None
     check_github_on_startup: Optional[bool] = None
-    http_port: Optional[int] = None
+    http_port: EmptyStringNullableInt = None
     log_dir: Optional[str] = None
-    update_db_interval: Optional[int] = None
+    update_db_interval: EmptyStringNullableInt = None
     allow_guest_access: Optional[bool] = None
     time_format: Optional[str] = None
     cache_dir: Optional[str] = None
     home_sections: Optional[List[str]] = None
-    backup_days: Optional[int] = None
+    backup_days: EmptyStringNullableInt = None
     https_cert: Optional[str] = None
     api_key: Optional[str] = None
     update_section_ids: Optional[bool] = None
@@ -223,7 +223,7 @@ class GeneralModel(BaseModel):
     git_branch: Optional[str] = None
     anon_redirect: Optional[str] = None
     http_plex_admin: Optional[bool] = None
-    update_show_changelog: Optional[int] = None
+    update_show_changelog: EmptyStringNullableInt = None
     show_advanced_settings: Optional[bool] = None
     git_remote: Optional[str] = None
     https_cert_chain: Optional[str] = None
@@ -235,24 +235,24 @@ class GeneralModel(BaseModel):
     themoviedb_lookup: Optional[bool] = None
     plexpy_auto_update: Optional[bool] = None
     update_libraries_db_notify: Optional[bool] = None
-    home_refresh_interval: Optional[int] = None
+    home_refresh_interval: EmptyStringNullableInt = None
     http_base_url: Optional[str] = None
     win_sys_tray: Optional[bool] = None
     musicbrainz_lookup: Optional[bool] = None
-    geoip_db_update_days: Optional[int] = None
+    geoip_db_update_days: EmptyStringNullableInt = None
     maxmind_license_key: Optional[str] = None
     geoip_db_installed: Optional[bool] = None
     launch_startup: Optional[bool] = None
     sys_tray_icon: Optional[bool] = None
     export_dir: Optional[str] = None
-    http_rate_limit_attempts: Optional[int] = None
-    http_rate_limit_attempts_interval: Optional[int] = None
-    http_rate_limit_lockout_time: Optional[int] = None
+    http_rate_limit_attempts: EmptyStringNullableInt = None
+    http_rate_limit_attempts_interval: EmptyStringNullableInt = None
+    http_rate_limit_lockout_time: EmptyStringNullableInt = None
     get_file_sizes_hold: Optional[GetFileSizesHoldModel] = None
     interface_list: Optional[List[str]] = None
 
 
-class SlackModel(BaseModel):
+class SlackModel(_Base):
     slack_on_stop: Optional[bool] = None
     slack_icon_emoji: Optional[str] = None
     slack_on_watched: Optional[bool] = None
@@ -277,7 +277,7 @@ class SlackModel(BaseModel):
     slack_on_newdevice: Optional[bool] = None
 
 
-class BoxcarModel(BaseModel):
+class BoxcarModel(_Base):
     boxcar_sound: Optional[str] = None
     boxcar_on_newdevice: Optional[bool] = None
     boxcar_on_watched: Optional[bool] = None
@@ -297,7 +297,7 @@ class BoxcarModel(BaseModel):
     boxcar_token: Optional[str] = None
 
 
-class PushBulletModel(BaseModel):
+class PushBulletModel(_Base):
     pushbullet_on_play: Optional[bool] = None
     pushbullet_channel_tag: Optional[str] = None
     pushbullet_on_buffer: Optional[bool] = None
@@ -318,7 +318,7 @@ class PushBulletModel(BaseModel):
     pushbullet_on_newdevice: Optional[bool] = None
 
 
-class ScriptsModel(BaseModel):
+class ScriptsModel(_Base):
     scripts_on_newdevice: Optional[bool] = None
     scripts_on_stop: Optional[bool] = None
     scripts_on_intdown_script: Optional[str] = None
@@ -346,13 +346,13 @@ class ScriptsModel(BaseModel):
     scripts_on_pause_script: Optional[str] = None
     scripts_on_pause: Optional[bool] = None
     scripts_on_intup: Optional[bool] = None
-    scripts_timeout: Optional[int] = None
+    scripts_timeout: EmptyStringNullableInt = None
     scripts_on_watched: Optional[bool] = None
     scripts_on_buffer_script: Optional[str] = None
     scripts_on_play: Optional[bool] = None
 
 
-class NMAModel(BaseModel):
+class NMAModel(_Base):
     nma_on_pmsupdate: Optional[bool] = None
     nma_priority: Optional[bool] = None
     nma_on_intdown: Optional[bool] = None
@@ -372,7 +372,7 @@ class NMAModel(BaseModel):
     nma_on_extup: Optional[bool] = None
 
 
-class HipchatModel(BaseModel):
+class HipchatModel(_Base):
     hipchat_emoticon: Optional[str] = None
     hipchat_incl_subject: Optional[bool] = None
     hipchat_on_extdown: Optional[bool] = None
@@ -396,7 +396,7 @@ class HipchatModel(BaseModel):
     hipchat_on_stop: Optional[bool] = None
 
 
-class PushalotModel(BaseModel):
+class PushalotModel(_Base):
     pushalot_apikey: Optional[str] = None
     pushalot_on_pmsupdate: Optional[bool] = None
     pushalot_enabled: Optional[bool] = None
@@ -415,7 +415,7 @@ class PushalotModel(BaseModel):
     pushalot_on_resume: Optional[bool] = None
 
 
-class ProwlModel(BaseModel):
+class ProwlModel(_Base):
     prowl_on_created: Optional[bool] = None
     prowl_on_play: Optional[bool] = None
     prowl_on_extdown: Optional[bool] = None
@@ -435,32 +435,32 @@ class ProwlModel(BaseModel):
     prowl_keys: Optional[str] = None
 
 
-class AdvancedModel(BaseModel):
+class AdvancedModel(_Base):
     verify_ssl_cert: Optional[bool] = None
     journal_mode: Optional[str] = None
-    pms_timeout: Optional[int] = None
-    cache_sizemb: Optional[int] = None
-    session_db_write_attempts: Optional[int] = None
+    pms_timeout: EmptyStringNullableInt = None
+    cache_sizemb: EmptyStringNullableInt = None
+    session_db_write_attempts: EmptyStringNullableInt = None
     system_analytics: Optional[bool] = None
-    notification_threads: Optional[int] = None
-    remote_access_ping_threshold: Optional[int] = None
-    websocket_connection_timeout: Optional[int] = None
-    config_version: Optional[int] = None
-    metadata_cache_seconds: Optional[int] = None
-    websocket_connection_attempts: Optional[int] = None
+    notification_threads: EmptyStringNullableInt = None
+    remote_access_ping_threshold: EmptyStringNullableInt = None
+    websocket_connection_timeout: EmptyStringNullableInt = None
+    config_version: EmptyStringNullableInt = None
+    metadata_cache_seconds: EmptyStringNullableInt = None
+    websocket_connection_attempts: EmptyStringNullableInt = None
     jwt_secret: Optional[str] = None
     websocket_monitor_ping_pong: Optional[bool] = None
     synchronous_mode: Optional[str] = None
-    pms_update_check_interval: Optional[int] = None
+    pms_update_check_interval: EmptyStringNullableInt = None
     jwt_update_secret: Optional[bool] = None
     verbose_logs: Optional[bool] = None
     add_live_tv_library: Optional[bool] = None
-    remote_access_ping_interval: Optional[int] = None
-    check_github_cache_seconds: Optional[int] = None
-    export_threads: Optional[int] = None
+    remote_access_ping_interval: EmptyStringNullableInt = None
+    check_github_cache_seconds: EmptyStringNullableInt = None
+    export_threads: EmptyStringNullableInt = None
 
 
-class FacebookModel(BaseModel):
+class FacebookModel(_Base):
     facebook_app_secret: Optional[str] = None
     facebook_on_stop: Optional[bool] = None
     facebook_token: Optional[str] = None
@@ -486,7 +486,7 @@ class FacebookModel(BaseModel):
     facebook_on_created: Optional[bool] = None
 
 
-class EmailModel(BaseModel):
+class EmailModel(_Base):
     email_from_name: Optional[str] = None
     email_bcc: Optional[str] = None
     email_on_pause: Optional[bool] = None
@@ -515,7 +515,7 @@ class EmailModel(BaseModel):
     email_on_play: Optional[bool] = None
 
 
-class OSXNotifyModel(BaseModel):
+class OSXNotifyModel(_Base):
     osx_notify_on_intdown: Optional[bool] = None
     osx_notify_on_buffer: Optional[bool] = None
     osx_notify_app: Optional[str] = None
@@ -534,14 +534,14 @@ class OSXNotifyModel(BaseModel):
     osx_notify_on_resume: Optional[bool] = None
 
 
-class PlexWatchModel(BaseModel):
+class PlexWatchModel(_Base):
     grouping_user_history: Optional[bool] = None
     plexwatch_database: Optional[str] = None
     grouping_global_history: Optional[bool] = None
     grouping_charts: Optional[bool] = None
 
 
-class PushoverModel(BaseModel):
+class PushoverModel(_Base):
     pushover_enabled: Optional[bool] = None
     pushover_on_extup: Optional[bool] = None
     pushover_on_intup: Optional[bool] = None
@@ -566,7 +566,7 @@ class PushoverModel(BaseModel):
     pushover_on_watched: Optional[bool] = None
 
 
-class TelegramModel(BaseModel):
+class TelegramModel(_Base):
     telegram_on_buffer: Optional[bool] = None
     telegram_bot_token: Optional[str] = None
     telegram_incl_poster: Optional[bool] = None
@@ -590,7 +590,7 @@ class TelegramModel(BaseModel):
     telegram_on_intup: Optional[bool] = None
 
 
-class TwitterModel(BaseModel):
+class TwitterModel(_Base):
     twitter_on_resume: Optional[bool] = None
     twitter_on_pmsupdate: Optional[bool] = None
     twitter_on_buffer: Optional[bool] = None
@@ -614,7 +614,7 @@ class TwitterModel(BaseModel):
     twitter_on_created: Optional[bool] = None
 
 
-class PlexModel(BaseModel):
+class PlexModel(_Base):
     plex_on_created: Optional[bool] = None
     plex_on_concurrent: Optional[bool] = None
     plex_client_host: Optional[str] = None
@@ -635,7 +635,7 @@ class PlexModel(BaseModel):
     plex_on_extup: Optional[bool] = None
 
 
-class JoinModel(BaseModel):
+class JoinModel(_Base):
     join_on_concurrent: Optional[bool] = None
     join_on_newdevice: Optional[bool] = None
     join_deviceid: Optional[str] = None
@@ -656,7 +656,7 @@ class JoinModel(BaseModel):
     join_on_stop: Optional[bool] = None
 
 
-class XBMCModel(BaseModel):
+class XBMCModel(_Base):
     xbmc_password: Optional[str] = None
     xbmc_on_play: Optional[bool] = None
     xbmc_on_pause: Optional[bool] = None
@@ -677,13 +677,13 @@ class XBMCModel(BaseModel):
     xbmc_on_concurrent: Optional[bool] = None
 
 
-class BrowserModel(BaseModel):
+class BrowserModel(_Base):
     browser_on_intdown: Optional[bool] = None
     browser_on_newdevice: Optional[bool] = None
     browser_on_pmsupdate: Optional[bool] = None
     browser_on_intup: Optional[bool] = None
     browser_on_buffer: Optional[bool] = None
-    browser_auto_hide_delay: Optional[int] = None
+    browser_auto_hide_delay: EmptyStringNullableInt = None
     browser_on_created: Optional[bool] = None
     browser_on_pause: Optional[bool] = None
     browser_on_stop: Optional[bool] = None
@@ -696,7 +696,7 @@ class BrowserModel(BaseModel):
     browser_enabled: Optional[bool] = None
 
 
-class NewsletterModel(BaseModel):
+class NewsletterModel(_Base):
     newsletter_dir: Optional[str] = None
     newsletter_templates: Optional[str] = None
     newsletter_self_hosted: Optional[bool] = None
@@ -707,13 +707,13 @@ class NewsletterModel(BaseModel):
     newsletter_auth: Optional[bool] = None
 
 
-class CloudinaryModel(BaseModel):
+class CloudinaryModel(_Base):
     cloudinary_api_key: Optional[str] = None
     cloudinary_cloud_name: Optional[str] = None
     cloudinary_api_secret: Optional[str] = None
 
 
-class SettingsModel(BaseModel):
+class SettingsModel(_Base):
     IFTTT: Optional[IFTTTModel] = None
     Growl: Optional[GrowlModel] = None
     PMS: Optional[PMSModel] = None

--- a/tautulli/models/status.py
+++ b/tautulli/models/status.py
@@ -4,11 +4,11 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base
 
 
-class StatusModel(BaseModel):
+class StatusModel(_Base):
     result: Optional[str] = None
     message: Any = None

--- a/tautulli/models/stream_data.py
+++ b/tautulli/models/stream_data.py
@@ -4,13 +4,13 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class StreamDataModel(BaseModel):
-    bitrate: Optional[int] = None
+class StreamDataModel(_Base):
+    bitrate: EmptyStringNullableInt = None
     video_full_resolution: Optional[str] = None
     optimized_version: Optional[str] = None
     optimized_version_profile: Optional[str] = None
@@ -19,32 +19,32 @@ class StreamDataModel(BaseModel):
     synced_version_profile: Optional[str] = None
     container: Optional[str] = None
     video_codec: Optional[str] = None
-    video_bitrate: Optional[int] = None
-    video_width: Optional[int] = None
-    video_height: Optional[int] = None
+    video_bitrate: EmptyStringNullableInt = None
+    video_width: EmptyStringNullableInt = None
+    video_height: EmptyStringNullableInt = None
     video_framerate: Optional[str] = None
     video_dynamic_range: Optional[str] = None
     aspect_ratio: Optional[str] = None
     audio_codec: Optional[str] = None
-    audio_bitrate: Optional[int] = None
-    audio_channels: Optional[int] = None
+    audio_bitrate: EmptyStringNullableInt = None
+    audio_channels: EmptyStringNullableInt = None
     subtitle_codec: Optional[str] = None
-    stream_bitrate: Optional[int] = None
+    stream_bitrate: EmptyStringNullableInt = None
     stream_video_full_resolution: Optional[str] = None
     quality_profile: Optional[str] = None
     stream_container_decision: Optional[str] = None
     stream_container: Optional[str] = None
     stream_video_decision: Optional[str] = None
     stream_video_codec: Optional[str] = None
-    stream_video_bitrate: Optional[int] = None
-    stream_video_width: Optional[int] = None
-    stream_video_height: Optional[int] = None
+    stream_video_bitrate: EmptyStringNullableInt = None
+    stream_video_width: EmptyStringNullableInt = None
+    stream_video_height: EmptyStringNullableInt = None
     stream_video_framerate: Optional[str] = None
     stream_video_dynamic_range: Optional[str] = None
     stream_audio_decision: Optional[str] = None
     stream_audio_codec: Optional[str] = None
-    stream_audio_bitrate: Optional[int] = None
-    stream_audio_channels: Optional[int] = None
+    stream_audio_bitrate: EmptyStringNullableInt = None
+    stream_audio_channels: EmptyStringNullableInt = None
     subtitles: Optional[str] = None
     stream_subtitle_decision: Optional[str] = None
     stream_subtitle_codec: Optional[str] = None
@@ -56,7 +56,7 @@ class StreamDataModel(BaseModel):
     title: Optional[str] = None
     grandparent_title: Optional[str] = None
     original_title: Optional[str] = None
-    current_session: Optional[int] = None
+    current_session: EmptyStringNullableInt = None
     pre_tautulli: Optional[str] = None
 
 

--- a/tautulli/models/synced_items.py
+++ b/tautulli/models/synced_items.py
@@ -4,12 +4,12 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class SyncedItemsModel(BaseModel):
+class SyncedItemsModel(_Base):
     audio_bitrate: Optional[str] = None
     client_id: Optional[str] = None
     content_type: Optional[str] = None
@@ -18,7 +18,7 @@ class SyncedItemsModel(BaseModel):
     item_complete_count: Optional[str] = None
     item_count: Optional[str] = None
     item_downloaded_count: Optional[str] = None
-    item_downloaded_percent_complete: Optional[int] = None
+    item_downloaded_percent_complete: EmptyStringNullableInt = None
     metadata_type: Optional[str] = None
     photo_quality: Optional[str] = None
     platform: Optional[str] = None

--- a/tautulli/models/tautulli_info.py
+++ b/tautulli/models/tautulli_info.py
@@ -6,10 +6,10 @@ from __future__ import annotations
 
 from typing import Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base
 
 
-class TautulliInfoModel(BaseModel):
+class TautulliInfoModel(_Base):
     tautulli_install_type: Optional[str] = None
     tautulli_version: Optional[str] = None
     tautulli_branch: Optional[str] = None

--- a/tautulli/models/update_check.py
+++ b/tautulli/models/update_check.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 
 from typing import Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base
 
 
-class UpdateCheckModel(BaseModel):
+class UpdateCheckModel(_Base):
     update: Optional[bool] = None
     install_type: Optional[str] = None

--- a/tautulli/models/user.py
+++ b/tautulli/models/user.py
@@ -4,27 +4,27 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import List, Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class UserModel(BaseModel):
-    row_id: Optional[int] = None
-    user_id: Optional[int] = None
+class UserModel(_Base):
+    row_id: EmptyStringNullableInt = None
+    user_id: EmptyStringNullableInt = None
     username: Optional[str] = None
     friendly_name: Optional[str] = None
     user_thumb: Optional[str] = None
     email: Optional[str] = None
-    is_active: Optional[int] = None
-    is_admin: Optional[int] = None
-    is_home_user: Optional[int] = None
-    is_allow_sync: Optional[int] = None
-    is_restricted: Optional[int] = None
-    do_notify: Optional[int] = None
-    keep_history: Optional[int] = None
-    allow_guest: Optional[int] = None
-    deleted_user: Optional[int] = None
+    is_active: EmptyStringNullableInt = None
+    is_admin: EmptyStringNullableInt = None
+    is_home_user: EmptyStringNullableInt = None
+    is_allow_sync: EmptyStringNullableInt = None
+    is_restricted: EmptyStringNullableInt = None
+    do_notify: EmptyStringNullableInt = None
+    keep_history: EmptyStringNullableInt = None
+    allow_guest: EmptyStringNullableInt = None
+    deleted_user: EmptyStringNullableInt = None
     shared_libraries: Optional[List] = None
 
 

--- a/tautulli/models/user_ips.py
+++ b/tautulli/models/user_ips.py
@@ -4,39 +4,39 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import List, Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class DatumModel(BaseModel):
+class DatumModel(_Base):
     friendly_name: Optional[str] = None
     guid: Optional[str] = None
-    id: Optional[int] = None
+    id: EmptyStringNullableInt = None
     ip_address: Optional[str] = None
     last_played: Optional[str] = None
-    last_seen: Optional[int] = None
-    first_seen: Optional[int] = None
-    live: Optional[int] = None
-    media_index: Optional[int] = None
+    last_seen: EmptyStringNullableInt = None
+    first_seen: EmptyStringNullableInt = None
+    live: EmptyStringNullableInt = None
+    media_index: EmptyStringNullableInt = None
     media_type: Optional[str] = None
     originally_available_at: Optional[str] = None
-    parent_media_index: Optional[int] = None
+    parent_media_index: EmptyStringNullableInt = None
     parent_title: Optional[str] = None
     platform: Optional[str] = None
-    play_count: Optional[int] = None
+    play_count: EmptyStringNullableInt = None
     player: Optional[str] = None
-    rating_key: Optional[int] = None
+    rating_key: EmptyStringNullableInt = None
     thumb: Optional[str] = None
     transcode_decision: Optional[str] = None
-    user_id: Optional[int] = None
-    year: Optional[int] = None
+    user_id: EmptyStringNullableInt = None
+    year: EmptyStringNullableInt = None
 
 
-class UserIPsModel(BaseModel):
-    draw: Optional[int] = None
-    recordsTotal: Optional[int] = None
-    recordsFiltered: Optional[int] = None
+class UserIPsModel(_Base):
+    draw: EmptyStringNullableInt = None
+    recordsTotal: EmptyStringNullableInt = None
+    recordsFiltered: EmptyStringNullableInt = None
     data: Optional[List[DatumModel]] = None
 
 

--- a/tautulli/models/user_logins.py
+++ b/tautulli/models/user_logins.py
@@ -4,28 +4,28 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import List, Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class DatumModel(BaseModel):
+class DatumModel(_Base):
     browser: Optional[str] = None
     friendly_name: Optional[str] = None
     host: Optional[str] = None
     ip_address: Optional[str] = None
     os: Optional[str] = None
-    timestamp: Optional[int] = None
+    timestamp: EmptyStringNullableInt = None
     user: Optional[str] = None
     user_agent: Optional[str] = None
     user_group: Optional[str] = None
-    user_id: Optional[int] = None
+    user_id: EmptyStringNullableInt = None
 
 
-class UserLoginsModel(BaseModel):
-    draw: Optional[int] = None
-    recordsTotal: Optional[int] = None
-    recordsFiltered: Optional[int] = None
+class UserLoginsModel(_Base):
+    draw: EmptyStringNullableInt = None
+    recordsTotal: EmptyStringNullableInt = None
+    recordsFiltered: EmptyStringNullableInt = None
     data: Optional[List[DatumModel]] = None
 
 

--- a/tautulli/models/user_player_stats.py
+++ b/tautulli/models/user_player_stats.py
@@ -4,17 +4,17 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class UserPlayerStatsModel(BaseModel):
+class UserPlayerStatsModel(_Base):
     platform: Optional[str] = None
     platform_name: Optional[str] = None
     player_name: Optional[str] = None
-    result_id: Optional[int] = None
-    total_plays: Optional[int] = None
+    result_id: EmptyStringNullableInt = None
+    total_plays: EmptyStringNullableInt = None
 
 
 

--- a/tautulli/models/user_watch_time_stats.py
+++ b/tautulli/models/user_watch_time_stats.py
@@ -4,15 +4,13 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
-
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class UserWatchTimeStatsModel(BaseModel):
-    query_days: Optional[int] = None
-    total_plays: Optional[int] = None
-    total_time: Optional[int] = None
+class UserWatchTimeStatsModel(_Base):
+    query_days: EmptyStringNullableInt = None
+    total_plays: EmptyStringNullableInt = None
+    total_time: EmptyStringNullableInt = None
 
 
 

--- a/tautulli/models/usernames.py
+++ b/tautulli/models/usernames.py
@@ -4,13 +4,13 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class UserNameModel(BaseModel):
-    user_id: Optional[int] = None
+class UserNameModel(_Base):
+    user_id: EmptyStringNullableInt = None
     friendly_name: Optional[str] = None
 
 

--- a/tautulli/models/users.py
+++ b/tautulli/models/users.py
@@ -4,26 +4,26 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import List, Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class UserModel(BaseModel):
-    row_id: Optional[int] = None
-    user_id: Optional[int] = None
+class UserModel(_Base):
+    row_id: EmptyStringNullableInt = None
+    user_id: EmptyStringNullableInt = None
     username: Optional[str] = None
     friendly_name: Optional[str] = None
     thumb: Optional[str] = None
     email: Optional[str] = None
-    is_active: Optional[int] = None
-    is_admin: Optional[int] = None
-    is_home_user: Optional[int] = None
-    is_allow_sync: Optional[int] = None
-    is_restricted: Optional[int] = None
-    do_notify: Optional[int] = None
-    keep_history: Optional[int] = None
-    allow_guest: Optional[int] = None
+    is_active: EmptyStringNullableInt = None
+    is_admin: EmptyStringNullableInt = None
+    is_home_user: EmptyStringNullableInt = None
+    is_allow_sync: EmptyStringNullableInt = None
+    is_restricted: EmptyStringNullableInt = None
+    do_notify: EmptyStringNullableInt = None
+    keep_history: EmptyStringNullableInt = None
+    allow_guest: EmptyStringNullableInt = None
     shared_libraries: Optional[List[str]] = None
     filter_all: Optional[str] = None
     filter_movies: Optional[str] = None

--- a/tautulli/models/users_table.py
+++ b/tautulli/models/users_table.py
@@ -4,49 +4,49 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base, EmptyStringNullableInt
 
 
-class DatumModel(BaseModel):
-    row_id: Optional[int] = None
-    user_id: Optional[int] = None
+class DatumModel(_Base):
+    row_id: EmptyStringNullableInt = None
+    user_id: EmptyStringNullableInt = None
     username: Optional[str] = None
     friendly_name: Optional[str] = None
     user_thumb: Optional[str] = None
-    plays: Optional[int] = None
-    duration: Optional[int] = None
-    last_seen: Optional[int] = None
+    plays: EmptyStringNullableInt = None
+    duration: EmptyStringNullableInt = None
+    last_seen: EmptyStringNullableInt = None
     last_played: Optional[str] = None
-    history_row_id: Optional[int] = None
+    history_row_id: EmptyStringNullableInt = None
     ip_address: Optional[str] = None
     platform: Optional[str] = None
     player: Optional[str] = None
-    rating_key: Optional[int] = None
+    rating_key: EmptyStringNullableInt = None
     media_type: Optional[str] = None
     thumb: Optional[str] = None
     parent_title: Optional[str] = None
     year: Optional[Any] = None
-    media_index: Optional[Union[int, str]] = None
-    parent_media_index: Optional[Union[int, str]] = None
-    live: Optional[int] = None
+    media_index: EmptyStringNullableInt = None
+    parent_media_index: EmptyStringNullableInt = None
+    live: EmptyStringNullableInt = None
     originally_available_at: Optional[str] = None
     guid: Optional[str] = None
     transcode_decision: Optional[str] = None
-    do_notify: Optional[int] = None
-    keep_history: Optional[int] = None
-    allow_guest: Optional[int] = None
-    is_active: Optional[int] = None
+    do_notify: EmptyStringNullableInt = None
+    keep_history: EmptyStringNullableInt = None
+    allow_guest: EmptyStringNullableInt = None
+    is_active: EmptyStringNullableInt = None
     title: Optional[str] = None
     email: Optional[str] = None
 
 
-class UsersTableModel(BaseModel):
-    recordsFiltered: Optional[int] = None
-    recordsTotal: Optional[int] = None
+class UsersTableModel(_Base):
+    recordsFiltered: EmptyStringNullableInt = None
+    recordsTotal: EmptyStringNullableInt = None
     data: Optional[List[DatumModel]] = None
-    draw: Optional[int] = None
+    draw: EmptyStringNullableInt = None
 
 
 

--- a/tautulli/models/whois_lookup.py
+++ b/tautulli/models/whois_lookup.py
@@ -4,12 +4,12 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import List, Optional
 
-from pydantic import BaseModel
+from tautulli.models._base import _Base
 
 
-class NetModel(BaseModel):
+class NetModel(_Base):
     cidr: Optional[str] = None
     name: Optional[str] = None
     handle: Optional[str] = None
@@ -25,7 +25,7 @@ class NetModel(BaseModel):
     updated: Optional[str] = None
 
 
-class WHOISLookupModel(BaseModel):
+class WHOISLookupModel(_Base):
     host: Optional[str] = None
     nets: Optional[List[NetModel]] = None
 

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -23,6 +23,7 @@ def raw_client(no_key: bool = False) -> tautulli.RawAPI:
         else:
             raise ValueError("T_KEY is not set and could not be retrieved from server")
 
+
 def invalid_raw_client() -> tautulli.RawAPI:
     load_dotenv()
     url = os.getenv("T_URL")
@@ -48,6 +49,7 @@ def object_client(no_key: bool = False) -> tautulli.ObjectAPI:
             return tautulli.ObjectAPI(base_url=url, api_key=key)
         else:
             raise ValueError("T_KEY is not set and could not be retrieved from server")
+
 
 def no_ssl_client(no_key: bool = False) -> tautulli.RawAPI:
     load_dotenv()


### PR DESCRIPTION
- Add annotated validator to coerce empty strings to None for nullable int/float values (in case API returns empty string for numerical fields)
- Add middle-man `_Base` class for Pydantic models (currently empty)

Closes #60 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved consistency across data models by switching to a custom base class.
	- Enhanced numeric field handling by replacing standard optional number types with refined types that gracefully convert empty values.
- **Style**
	- Introduced minor spacing adjustments in test files to improve readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->