### PR TITLE
Fix Python 3.13 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ test.py
 /scratch.py
 /tautulli/models/data.json
 /reference/
+.idea

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 objectrest==2.0.*
-pydantic==2.6.*
+pydantic==2.10.*
 pytz==2024.*
 python-dotenv==1.0.*
 packaging==24.*


### PR DESCRIPTION
- Bump Pydantic to 2.10.* for Python 3.13 support

Closes #62 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated project configuration to exclude local developer settings.
  - Upgraded the key dependency to version 2.10, ensuring access to the latest improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->